### PR TITLE
Update license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
    "name":"ycloudyusa/yusaopeny-project",
    "description":"Project template for OpenY projects with composer",
    "type":"project",
-   "license":"GPL-2.0+",
+   "license":"GPL-2.0-or-later",
    "require":{
       "ycloudyusa/yusaopeny":"^10.3.1.1 || dev-main",
       "cweagans/composer-patches":"~1.0 || ^2"


### PR DESCRIPTION
Validators flag: License "GPL-2.0+" is a deprecated SPDX license identifier, use "GPL-2.0-or-later" instead