### PR TITLE
feat: add custom version for lb_claro to support drupal 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
          "source":{
             "url":"https://git.drupalcode.org/issue/lb_claro-3525552.git",
             "type":"git",
-            "reference":"3525552-drupal-11-compability"
+            "reference":"3525552-drupal-11-update"
          }
       }
    },


### PR DESCRIPTION
This module do not have composer.json so used package type with reference to git https://www.drupal.org/project/lb_claro/issues/3525552