### PR TITLE
fix: CSS class is not added to MediaLibrary dialog

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -193,6 +193,11 @@
       "docksal":"[ -d ./vendor/ymcatwincities/openy-docksal ] && (rsync -r --exclude=composer.json --exclude=.git --exclude=README.md ./vendor/ymcatwincities/openy-docksal/ ./) || (rm -rf .docksal build.sh)"
    },
    "extra":{
+      "patches": {
+         "drupal/core": {
+            "Class is not added to MediaLibrary dialog": "https://git.drupalcode.org/project/drupal/-/merge_requests/12597.diff"
+         }
+      },
       "installer-types":[
          "bower-asset",
          "npm-asset"


### PR DESCRIPTION
Issue: https://www.drupal.org/project/drupal/issues/3474018
Patch with fix: https://git.drupalcode.org/project/drupal/-/merge_requests/12597

<img width="1490" height="935" alt="image" src="https://github.com/user-attachments/assets/1afec650-c47d-4a6f-a458-9285cf91d5d5" />
