### PR TITLE
feat: allow symfony/runtime composer plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -214,7 +214,8 @@
          "drupal/core-composer-scaffold": true,
          "drupal/core-project-message": true,
          "oomphinc/composer-installers-extender": true,
-         "mglaman/composer-drupal-lenient": true
+         "mglaman/composer-drupal-lenient": true,
+         "symfony/runtime": true
       }
    }
 }


### PR DESCRIPTION
## Summary
Drupal 11.4 introduces `symfony/runtime` as a transitive dependency. It ships a composer plugin which must be whitelisted in `allow-plugins`, otherwise `composer install` fails:

\`\`\`
symfony/runtime contains a Composer plugin which is blocked by your allow-plugins config.
\`\`\`

Related: https://github.com/YCloudYUSA/yusaopeny/pull/372 (Drupal 11.4 support).

## Test plan
- [ ] `composer create-project ycloudyusa/yusaopeny-project` succeeds with Drupal 11.4.x-dev
- [ ] No `PluginManager.php` exception during install