### PR TITLE
chore: remove deprecated CKEditor 4 library repositories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,66 +41,6 @@
       {
          "type": "package",
          "package": {
-            "name": "library-ckeditor/panelbutton",
-            "version": "4.10.1",
-            "type": "drupal-library",
-            "dist": {
-               "url": "http://download.ckeditor.com/panelbutton/releases/panelbutton_4.10.1.zip",
-               "type": "zip"
-            }
-         }
-      },
-      {
-         "type": "package",
-         "package": {
-            "name": "library-ckeditor/colorbutton",
-            "version": "4.10.1",
-            "type": "drupal-library",
-            "dist": {
-               "url": "http://download.ckeditor.com/colorbutton/releases/colorbutton_4.10.1.zip",
-               "type": "zip"
-            }
-         }
-      },
-      {
-         "type": "package",
-         "package": {
-            "name": "library-ckeditor/colordialog",
-            "version": "4.10.1",
-            "type": "drupal-library",
-            "dist": {
-               "url": "http://download.ckeditor.com/colordialog/releases/colordialog_4.10.1.zip",
-               "type": "zip"
-            }
-         }
-      },
-      {
-         "type": "package",
-         "package": {
-            "name": "library-ckeditor/glyphicons",
-            "version": "2.2",
-            "type": "drupal-library",
-            "dist": {
-               "url": "http://download.ckeditor.com/glyphicons/releases/glyphicons_2.2.zip",
-               "type": "zip"
-            }
-         }
-      },
-      {
-         "type": "package",
-         "package": {
-            "name": "library-ckeditor/font",
-            "version": "4.12.1",
-            "type": "drupal-library",
-            "dist": {
-               "url": "https://download.ckeditor.com/font/releases/font_4.12.1.zip",
-               "type": "zip"
-            }
-         }
-      },
-      {
-         "type": "package",
-         "package": {
             "name": "library-smonetti/btbutton",
             "version": "1.0.2",
             "type": "drupal-library",


### PR DESCRIPTION
> [!WARNING]
> **Merge order — do NOT merge this PR alone.** This depends on YCloudYUSA/yusaopeny#374.
> Merge **#374 first** (it drops the profile `require library-ckeditor/*`), then this PR.
> Merging this earlier breaks `composer install`: the profile still requires `font`, `colorbutton`, `panelbutton`, and Composer reads `repositories` only from this root template.

## What

Removes all custom package `repositories` declarations for the deprecated CKEditor 4 library plugins:

- `library-ckeditor/font` (4.12.1)
- `library-ckeditor/panelbutton` (4.10.1)
- `library-ckeditor/colorbutton` (4.10.1)
- `library-ckeditor/colordialog` (4.10.1)
- `library-ckeditor/glyphicons` (2.2)

## Why

Composer only reads `repositories` from the root template, so these declarations exist solely to satisfy the profile's `require`. CKEditor 4 is gone in Drupal 10/11; the distro uses CKEditor 5. `colordialog` and `glyphicons` are already orphans (required by nothing); the rest become orphans once the profile drops its requires. All point at the external EOL `download.ckeditor.com` host (the four CKE4 button/dialog plugins over plain `http://`).

## Scope

All five CKEditor 4 repo declarations.

## Coordination

Depends on YCloudYUSA/yusaopeny#374 (drops `require library-ckeditor/*`). **Merge this AFTER #374.**

## Test plan

- `composer validate` passes
- fresh `composer create-project` succeeds with the updated profile
